### PR TITLE
Fix circular import issue.

### DIFF
--- a/auto_tagify2/__init__.py
+++ b/auto_tagify2/__init__.py
@@ -1,1 +1,1 @@
-from auto_tagify import AutoTagify
+from .auto_tagify2 import AutoTagify


### PR DESCRIPTION
The `__init__.py` file contained a circular import which has been removed.
The package has been tested with both Python 2.7.17 and 3.8.

Would it be possible to update the `auto_tagify2` pip package as well?

Thank you,
Gilles